### PR TITLE
Automatic start of the follower and setup instructions

### DIFF
--- a/Dockerfile.roboquest_arms
+++ b/Dockerfile.roboquest_arms
@@ -17,6 +17,7 @@ RUN apt-get install -y cmake build-essential python-dev-is-python3 pkg-config
 
 WORKDIR /usr/src/rq_arms
 COPY lerobot lerobot
+COPY scripts scripts
 WORKDIR /root/.cache/huggingface/lerobot/calibration/robots/so101_follower
 COPY lerobot/arm_follow.json /root/.cache/huggingface/lerobot/calibration/robots/so101_follower
 WORKDIR /usr/src/rq_arms
@@ -26,4 +27,4 @@ RUN conda activate rq_arms ; \
     pip install feetech-servo-sdk huggingface-hub pyserial deepdiff numpy draccus
 
 ENTRYPOINT ["/bin/bash", "--login"]
-#CMD ["/usr/src/start.sh"]
+CMD ["/usr/src/rq_arms/scripts/start.sh"]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Supports SO101 arms built with FeeTech servoes, with the leader arm connected to
 machine and the follower connected to a Raspberry Pi (or more capable machine with Docker
 support). The follower software id deployed via a Docker image.
 
-# Build the rq_arms image for the follower
+# Setup for the follower
 
 1. clone the repo
 2. cd to the root of the repo
@@ -15,15 +15,10 @@ Alternatively:
 
 1. docker pull registry.q4excellence.com:5678/rq_arms
 
-# Setup for the leader
-
-1. install miniconda
-2. create the virtual environment
-3. install the packages
-
 # Run the follower components
 
-In the following command lines, replace <FOLLOWER SERIAL PORT>
+In the following command lines, executed on the robot to which
+the follower arm is physically connected, replace <FOLLOWER SERIAL PORT>
 with the full device file name, usually something like
 /dev/ttyACM0.
 Replace <IP address of leader> with the IP address where the
@@ -47,3 +42,28 @@ docker run \
 
 After the Docker container is started, the follower software will
 be automatically started.
+
+# Setup for the leader
+
+1. install miniconda
+    1. cd ~
+    2. wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+    3. bash ~/Miniconda3-latest-Linux-x86_64.sh
+    4. conda init --all
+2. create the virtual environment
+    1. conda create -y -n rq_arms python 3.12
+3. install the packages
+    1. git clone https://github.com/billmania/roboquest_arms.git
+    2. cd roboquest_arms
+    3. pip install feetech-servo-sdk huggingface-hub pyserial deepdiff numpy draccus
+
+# Run the leader components
+
+```
+python -m lerobot.teleoperate_leader \
+    --teleop.socket_ip 0.0.0.0 \
+    --teleop.socket_port <port number of leader> \
+    --teleop.type so101_leader \
+    --teleop.port <LEADER SERIAL PORT> \
+    --teleop.id arm_lead
+```

--- a/README.md
+++ b/README.md
@@ -11,8 +11,39 @@ support). The follower software id deployed via a Docker image.
 2. cd to the root of the repo
 3. docker build -t registry.q4excellence.com:5678/rq_arms -f Dockerfile.roboquest_arms .
 
+Alternatively:
+
+1. docker pull registry.q4excellence.com:5678/rq_arms
+
 # Setup for the leader
 
 1. install miniconda
 2. create the virtual environment
 3. install the packages
+
+# Run the follower components
+
+In the following command lines, replace <FOLLOWER SERIAL PORT>
+with the full device file name, usually something like
+/dev/ttyACM0.
+Replace <IP address of leader> with the IP address where the
+leader components are running, something like 192.168.0.12.
+Replace <port number of leader> with the port number for the
+leader, something like 8888.
+
+```
+docker run \
+    -it \
+    --rm \
+    --privileged \
+    --network host \
+    --ipc host \
+    --device <FOLLOWER SERIAL PORT>:/dev/arm_follow \
+    -e LEADER_IP='<IP address of leader>' \
+    -e LEADER_PORT='<port number of leader>' \
+    --name rq_arms \
+    registry.q4excellence.com:5678/rq_arms
+```
+
+After the Docker container is started, the follower software will
+be automatically started.

--- a/lerobot/teleoperate_follower.py
+++ b/lerobot/teleoperate_follower.py
@@ -18,6 +18,7 @@ import pickle
 import socket
 import time
 from dataclasses import dataclass, field
+from os import environ
 from pathlib import Path
 
 from lerobot.common.robots import (
@@ -34,8 +35,8 @@ class Robot_Config:
     type: str = 'so101_follower'  # noqa: A003
     port: str = '/dev/arm_follow'
     id: str = 'arm_follow'  # noqa: A003
-    socket_ip: str = '192.168.0.10'
-    socket_port: int = 8888
+    socket_ip: str = environ['LEADER_IP']
+    socket_port: int = int(environ['LEADER_PORT'])
     calibration_dir: Path | None = Path(
         '/root/.cache/huggingface/lerobot/calibration/robots/so101_follower'
     )

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+conda activate rq_arms
+python -m lerobot.teleoperate_follower


### PR DESCRIPTION
Fleshed out the README with instructions to install the software and start it.
Added a start.sh script to the Docker image, so the follower logic will start automatically.

Added the environment variables LEADER_IP and LEADER_PORT for the follower Docker container.